### PR TITLE
Expose fields for subclass.

### DIFF
--- a/library/src/main/java/com/unnamed/b/atv/view/AndroidTreeView.java
+++ b/library/src/main/java/com/unnamed/b/atv/view/AndroidTreeView.java
@@ -26,7 +26,7 @@ import java.util.Set;
 public class AndroidTreeView {
     private static final String NODES_PATH_SEPARATOR = ";";
 
-    private TreeNode mRoot;
+    protected TreeNode mRoot;
     private Context mContext;
     private boolean applyForRoot;
     private int containerStyle = 0;
@@ -36,6 +36,14 @@ public class AndroidTreeView {
     private boolean mSelectionModeEnabled;
     private boolean mUseDefaultAnimation = false;
     private boolean use2dScroll = false;
+
+    public AndroidTreeView(Context context) {
+        mContext = context;
+    }
+
+    public void setRoot(TreeNode mRoot) {
+        this.mRoot = mRoot;
+    }
 
     public AndroidTreeView(Context context, TreeNode root) {
         mRoot = root;

--- a/library/src/main/java/com/unnamed/b/atv/view/TreeNodeWrapperView.java
+++ b/library/src/main/java/com/unnamed/b/atv/view/TreeNodeWrapperView.java
@@ -46,4 +46,7 @@ public class TreeNodeWrapperView extends LinearLayout {
         nodeContainer.addView(nodeView);
     }
 
+    public ViewGroup getNodeContainer() {
+        return nodeContainer;
+    }
 }


### PR DESCRIPTION
Hi,

The pull request changes are for the following reasons.

1. I am currently writing a FileTreeView which has the interface

   ```java

    public FileTreeView(Context context, File file) {
        super(context);
        TreeNode root = TreeNode.root();
        setUpNode(root, file);
        setRoot(root);
    }
   ```
This requires creating a root node before initialising the superclass AndroidTreeView.

2. mRoot usually needs to be visited in subclasses when writing a custom traverse method. I changed it to protected.

3. I have the need to access the nodeContainer from others classes.
For example, I want to set the background of a single row to a certain colour.
```java
this.highlightedNode.getViewHolder().getView().setBackgroundColor(color);;
```
This would colour all the children nodes.

Instead, I would like to do something like this:

```java
view = (TreeNodeWrapperView) this.highlightedNode.getViewHolder().getView();
view.getNodeContainer().setBackgroundColor(color);
```