### PR TITLE
Added disable for auto tree node toggle, and test use case

### DIFF
--- a/app/src/main/java/com/unnamed/b/atv/sample/activity/MainActivity.java
+++ b/app/src/main/java/com/unnamed/b/atv/sample/activity/MainActivity.java
@@ -13,6 +13,7 @@ import com.unnamed.b.atv.sample.R;
 import com.unnamed.b.atv.sample.fragment.CustomViewHolderFragment;
 import com.unnamed.b.atv.sample.fragment.FolderStructureFragment;
 import com.unnamed.b.atv.sample.fragment.SelectableTreeFragment;
+import com.unnamed.b.atv.sample.fragment.TwoDScrollingArrowExpandFragment;
 import com.unnamed.b.atv.sample.fragment.TwoDScrollingFragment;
 
 import java.util.ArrayList;
@@ -34,6 +35,7 @@ public class MainActivity extends ActionBarActivity {
         listItems.put("Custom Holder Example", CustomViewHolderFragment.class);
         listItems.put("Selectable Nodes", SelectableTreeFragment.class);
         listItems.put("2d scrolling", TwoDScrollingFragment.class);
+        listItems.put("Expand with arrow only", TwoDScrollingArrowExpandFragment.class);
 
 
         final List<String> list = new ArrayList(listItems.keySet());

--- a/app/src/main/java/com/unnamed/b/atv/sample/fragment/TwoDScrollingArrowExpandFragment.java
+++ b/app/src/main/java/com/unnamed/b/atv/sample/fragment/TwoDScrollingArrowExpandFragment.java
@@ -1,0 +1,82 @@
+package com.unnamed.b.atv.sample.fragment;
+
+import android.app.Fragment;
+import android.os.Bundle;
+import android.text.TextUtils;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.Toast;
+
+import com.unnamed.b.atv.model.TreeNode;
+import com.unnamed.b.atv.sample.R;
+import com.unnamed.b.atv.sample.holder.ArrowExpandSelectableHeaderHolder;
+import com.unnamed.b.atv.sample.holder.IconTreeItemHolder;
+import com.unnamed.b.atv.view.AndroidTreeView;
+
+/**
+ * Created by Bogdan Melnychuk on 2/12/15 modified by Szigeti Peter 2/2/16.
+ */
+public class TwoDScrollingArrowExpandFragment extends Fragment implements TreeNode.TreeNodeClickListener{
+    private static final String NAME = "Very long name for folder";
+    private AndroidTreeView tView;
+
+    @Override
+    public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
+        View rootView = inflater.inflate(R.layout.fragment_selectable_nodes, null, false);
+        rootView.findViewById(R.id.status).setVisibility(View.GONE);
+        ViewGroup containerView = (ViewGroup) rootView.findViewById(R.id.container);
+
+        TreeNode root = TreeNode.root();
+
+        TreeNode s1 = new TreeNode(new IconTreeItemHolder.IconTreeItem(R.string.ic_folder, "Folder with very long name ")).setViewHolder(
+            new ArrowExpandSelectableHeaderHolder(getActivity()));
+        TreeNode s2 = new TreeNode(new IconTreeItemHolder.IconTreeItem(R.string.ic_folder, "Another folder with very long name")).setViewHolder(
+            new ArrowExpandSelectableHeaderHolder(getActivity()));
+
+        fillFolder(s1);
+        fillFolder(s2);
+
+        root.addChildren(s1, s2);
+
+        tView = new AndroidTreeView(getActivity(), root);
+        tView.setDefaultAnimation(true);
+        tView.setUse2dScroll(true);
+        tView.setDefaultContainerStyle(R.style.TreeNodeStyleCustom);
+        tView.setDefaultNodeClickListener(TwoDScrollingArrowExpandFragment.this);
+        tView.setDefaultViewHolder(ArrowExpandSelectableHeaderHolder.class);
+        containerView.addView(tView.getView());
+        tView.setUseAutoToggle(false);
+
+        tView.expandAll();
+
+        if (savedInstanceState != null) {
+            String state = savedInstanceState.getString("tState");
+            if (!TextUtils.isEmpty(state)) {
+                tView.restoreState(state);
+            }
+        }
+        return rootView;
+    }
+
+    private void fillFolder(TreeNode folder) {
+        TreeNode currentNode = folder;
+        for (int i = 0; i < 4; i++) {
+            TreeNode file = new TreeNode(new IconTreeItemHolder.IconTreeItem(R.string.ic_folder, NAME + " " + i));
+            currentNode.addChild(file);
+            currentNode = file;
+        }
+    }
+
+    @Override
+    public void onSaveInstanceState(Bundle outState) {
+        super.onSaveInstanceState(outState);
+        outState.putString("tState", tView.getSaveState());
+    }
+
+    @Override
+    public void onClick(TreeNode node, Object value) {
+        Toast toast = Toast.makeText(getActivity(), ((IconTreeItemHolder.IconTreeItem)value).text, Toast.LENGTH_SHORT);
+        toast.show();
+    }
+}

--- a/app/src/main/java/com/unnamed/b/atv/sample/holder/ArrowExpandSelectableHeaderHolder.java
+++ b/app/src/main/java/com/unnamed/b/atv/sample/holder/ArrowExpandSelectableHeaderHolder.java
@@ -1,0 +1,74 @@
+package com.unnamed.b.atv.sample.holder;
+
+import android.content.Context;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.widget.CheckBox;
+import android.widget.CompoundButton;
+import android.widget.TextView;
+
+import com.github.johnkil.print.PrintView;
+import com.unnamed.b.atv.model.TreeNode;
+import com.unnamed.b.atv.sample.R;
+
+/**
+ * Created by Bogdan Melnychuk on 2/15/15, modified by Szigeti Peter 2/2/16.
+ */
+public class ArrowExpandSelectableHeaderHolder extends TreeNode.BaseNodeViewHolder<IconTreeItemHolder.IconTreeItem> {
+    private TextView tvValue;
+    private PrintView arrowView;
+    private CheckBox nodeSelector;
+
+    public ArrowExpandSelectableHeaderHolder(Context context) {
+        super(context);
+    }
+
+    @Override
+    public View createNodeView(final TreeNode node, IconTreeItemHolder.IconTreeItem value) {
+        final LayoutInflater inflater = LayoutInflater.from(context);
+        final View view = inflater.inflate(R.layout.layout_selectable_header, null, false);
+
+        tvValue = (TextView) view.findViewById(R.id.node_value);
+        tvValue.setText(value.text);
+
+        final PrintView iconView = (PrintView) view.findViewById(R.id.icon);
+        iconView.setIconText(context.getResources().getString(value.icon));
+
+        arrowView = (PrintView) view.findViewById(R.id.arrow_icon);
+        arrowView.setPadding(20,10,10,10);
+        if (node.isLeaf()) {
+            arrowView.setVisibility(View.GONE);
+        }
+        arrowView.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View view) {
+                tView.toggleNode(node);
+            }
+        });
+
+        nodeSelector = (CheckBox) view.findViewById(R.id.node_selector);
+        nodeSelector.setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
+            @Override
+            public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {
+                node.setSelected(isChecked);
+                for (TreeNode n : node.getChildren()) {
+                    getTreeView().selectNode(n, isChecked);
+                }
+            }
+        });
+        nodeSelector.setChecked(node.isSelected());
+
+        return view;
+    }
+
+    @Override
+    public void toggle(boolean active) {
+        arrowView.setIconText(context.getResources().getString(active ? R.string.ic_keyboard_arrow_down : R.string.ic_keyboard_arrow_right));
+    }
+
+    @Override
+    public void toggleSelectionMode(boolean editModeEnabled) {
+        nodeSelector.setVisibility(editModeEnabled ? View.VISIBLE : View.GONE);
+        nodeSelector.setChecked(mNode.isSelected());
+    }
+}

--- a/library/src/main/java/com/unnamed/b/atv/view/AndroidTreeView.java
+++ b/library/src/main/java/com/unnamed/b/atv/view/AndroidTreeView.java
@@ -36,6 +36,7 @@ public class AndroidTreeView {
     private boolean mSelectionModeEnabled;
     private boolean mUseDefaultAnimation = false;
     private boolean use2dScroll = false;
+    private boolean enableAutoToggle = true;
 
     public AndroidTreeView(Context context) {
         mContext = context;
@@ -69,6 +70,14 @@ public class AndroidTreeView {
 
     public boolean is2dScrollEnabled() {
         return use2dScroll;
+    }
+
+    public void setUseAutoToggle(boolean enableAutoToggle) {
+        this.enableAutoToggle = enableAutoToggle;
+    }
+
+    public boolean isAutoToggleEnabled() {
+        return enableAutoToggle;
     }
 
     public void setDefaultViewHolder(Class<? extends TreeNode.BaseNodeViewHolder> viewHolder) {
@@ -194,7 +203,7 @@ public class AndroidTreeView {
         }
     }
 
-    private void toggleNode(TreeNode node) {
+    public void toggleNode(TreeNode node) {
         if (node.isExpanded()) {
             collapseNode(node, false);
         } else {
@@ -260,7 +269,9 @@ public class AndroidTreeView {
                 } else if (nodeClickListener != null) {
                     nodeClickListener.onClick(n, n.getValue());
                 }
-                toggleNode(n);
+                if (enableAutoToggle) {
+                    toggleNode(n);
+                }
             }
         });
 
@@ -271,6 +282,9 @@ public class AndroidTreeView {
                     return n.getLongClickListener().onLongClick(n, n.getValue());
                 } else if (nodeLongClickListener != null) {
                     return nodeLongClickListener.onLongClick(n, n.getValue());
+                }
+                if (enableAutoToggle) {
+                    toggleNode(n);
                 }
                 return false;
             }


### PR DESCRIPTION
This change enables the user to disable the auto toggle function of the tree nodes. 
This way one can bind the any part of the view for example the arrow, to make the node collapse or expand in the NodeViewHolder. 

This is useful if one needs to select a node without opening the children. 