### PR TITLE
Prevent margin clicks from going to the parent node

### DIFF
--- a/library/src/main/java/com/unnamed/b/atv/model/TreeNode.java
+++ b/library/src/main/java/com/unnamed/b/atv/model/TreeNode.java
@@ -222,6 +222,7 @@ public class TreeNode {
     public static abstract class BaseNodeViewHolder<E> {
         protected AndroidTreeView tView;
         protected TreeNode mNode;
+        private View nodeView;
         private View mView;
         protected int containerStyle;
         protected Context context;
@@ -234,12 +235,20 @@ public class TreeNode {
             if (mView != null) {
                 return mView;
             }
-            final View nodeView = getNodeView();
+            nodeView = getNodeView();
             final TreeNodeWrapperView nodeWrapperView = new TreeNodeWrapperView(nodeView.getContext(), getContainerStyle());
             nodeWrapperView.insertNodeView(nodeView);
             mView = nodeWrapperView;
 
             return mView;
+        }
+
+        public void setOnClickListener(View.OnClickListener listener) {
+            nodeView.setOnClickListener(listener);
+        }
+
+        public void setOnLongClickListener(View.OnLongClickListener listener) {
+            nodeView.setOnLongClickListener(listener);
         }
 
         public void setTreeViev(AndroidTreeView treeViev) {

--- a/library/src/main/java/com/unnamed/b/atv/model/TreeNode.java
+++ b/library/src/main/java/com/unnamed/b/atv/model/TreeNode.java
@@ -251,8 +251,8 @@ public class TreeNode {
             nodeView.setOnLongClickListener(listener);
         }
 
-        public void setTreeViev(AndroidTreeView treeViev) {
-            this.tView = treeViev;
+        public void setTreeView(AndroidTreeView treeView) {
+            this.tView = treeView;
         }
 
         public AndroidTreeView getTreeView() {

--- a/library/src/main/java/com/unnamed/b/atv/view/AndroidTreeView.java
+++ b/library/src/main/java/com/unnamed/b/atv/view/AndroidTreeView.java
@@ -408,7 +408,7 @@ public class AndroidTreeView {
             viewHolder.setContainerStyle(containerStyle);
         }
         if (viewHolder.getTreeView() == null) {
-            viewHolder.setTreeViev(this);
+            viewHolder.setTreeView(this);
         }
         return viewHolder;
     }

--- a/library/src/main/java/com/unnamed/b/atv/view/AndroidTreeView.java
+++ b/library/src/main/java/com/unnamed/b/atv/view/AndroidTreeView.java
@@ -261,7 +261,7 @@ public class AndroidTreeView {
             viewHolder.toggleSelectionMode(mSelectionModeEnabled);
         }
 
-        nodeView.setOnClickListener(new View.OnClickListener() {
+        viewHolder.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
                 if (n.getClickListener() != null) {
@@ -275,7 +275,7 @@ public class AndroidTreeView {
             }
         });
 
-        nodeView.setOnLongClickListener(new View.OnLongClickListener() {
+        viewHolder.setOnLongClickListener(new View.OnLongClickListener() {
             @Override
             public boolean onLongClick(View view) {
                 if (n.getLongClickListener() != null) {


### PR DESCRIPTION
Thank you for this great library! When using version 1.2.9 of it I noted that clicks in the indentation area of child nodes go to the parent node, normally collapsing it. I found this behavior not correct, so in commit 68a5d1c I changed the code to attach the handlers to the nodeView instead of the nodeWrapperView. I found it easiest to achieve this by using two additional methods in BaseNodeViewHolder, but there might be better ways to achieve the same result.

In my second commit ac5b9a7 I corrected a typo in one of your method names. Feel free to ignore it if it breaks compatibility with existing code too much.